### PR TITLE
:construction_worker: Ensure color is reset after echo command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,5 +169,5 @@ $(GOFUMPT_BIN):
 
 # $(call echo_msg, <emoji>, <action>, <object>, <context>)
 define echo_msg
-	@echo "$(strip $(1)) ${COLOR_GREEN}$(strip $(2))${COLOR_RESET} ${COLOR_CYAN}$(strip $(3))${COLOR_RESET} $(strip $(4))"
+	@echo "$(strip $(1)) ${COLOR_GREEN}$(strip $(2))${COLOR_RESET} ${COLOR_CYAN}$(strip $(3))${COLOR_RESET} $(strip $(4))${COLOR_RESET}"
 endef


### PR DESCRIPTION
Self explanatory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Terminal output now resets color formatting properly, ensuring that subsequent terminal messages display as expected without unintended color effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->